### PR TITLE
Fix a bug in regex mechanism

### DIFF
--- a/src/main/java/com/github/dakusui/jcunit/regex/RegexToFactorListTranslator.java
+++ b/src/main/java/com/github/dakusui/jcunit/regex/RegexToFactorListTranslator.java
@@ -84,8 +84,10 @@ public class RegexToFactorListTranslator implements Expr.Visitor {
     final Factors.Builder builder = new Factors.Builder();
     for (String eachKey : this.terms.keySet()) {
       Factor.Builder b = new Factor.Builder(eachKey);
-      if (isReferencedByAltDirectlyOrIndirectly(eachKey) || isAlt(eachKey)) {
-        b.addLevel(VOID);
+      if (!isTopLevel(eachKey)) {
+        if (isReferencedByAltDirectlyOrIndirectly(eachKey) || isAlt(eachKey)) {
+          b.addLevel(VOID);
+        }
       }
       if (isAlt(eachKey)) {
         for (Value eachValue : this.terms.get(eachKey)) {
@@ -99,11 +101,15 @@ public class RegexToFactorListTranslator implements Expr.Visitor {
         }
         b.addLevel(work);
       }
-      if (b.size() > 1 || (b.size() == 1 && composeKey(this.prefix, this.topLevelExpression.id()).equals(eachKey))) {
+      if (b.size() > 1 || (b.size() == 1 && isTopLevel(eachKey))) {
         builder.add(b.build());
       }
     }
     return builder.build();
+  }
+
+  private boolean isTopLevel(String eachKey) {
+    return composeKey(this.prefix, this.topLevelExpression.id()).equals(eachKey);
   }
 
   public List<TestSuite.Predicate> buildConstraints(List<Factor> factors) {

--- a/src/test/java/com/github/dakusui/jcunit/irregex/expressions/ParserTest.java
+++ b/src/test/java/com/github/dakusui/jcunit/irregex/expressions/ParserTest.java
@@ -70,7 +70,9 @@ public class ParserTest {
       /*23*/ "(A|B|C);A,B,C;(*(+ABC))",
       /*24*/ "(A|B|(C(D{0,1})));A,B,CD,C;(*(+AB(*C(*D{0,1}))))",
       /*25*/ "((A{0,1})|B|(C{0,1}));,,A,B,C;(*(+(*A{0,1})B(*C{0,1})))", // limitation; where multiple component can result in the same result can produce the same test cases.
-      /*26*/ "((A{0,1})|B|(C{0,1}D{0,1}));,,A,B,C,CD,D;(*(+(*A{0,1})B(*C{0,1}D{0,1})))" // limitation. see above
+      /*26*/ "((A{0,1})|B|(C{0,1}D{0,1}));,,A,B,C,CD,D;(*(+(*A{0,1})B(*C{0,1}D{0,1})))", // limitation. see above
+      /*27*/ "A|B|C;A,B,C;(+ABC)",
+      /*28*/ "(A)|(B)|(C);A,B,C;(+(*A)(*B)(*C))"
   })
   public String _input;
 


### PR DESCRIPTION
Fix a bug in regex mechanism where unnecessary empty test case is generated when "|"(choice) oprator is used at top level.