### PR TITLE
Issue-#196: Rename ParseConfigWith to ParseConfigArgumentsWith

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,14 @@
     <name>jcunit</name>
     <url>http://dakusui.github.io/${project.name}</url>
 
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <scm>
         <connection>scm:git:git@github.com/dakusui/${project.name}.git
         </connection>
@@ -20,14 +28,6 @@
         <url>https://github.com/dakusui/${project.name}</url>
         <tag>${project.name}-${project.version}</tag>
     </scm>
-
-    <licenses>
-        <license>
-            <name>Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <developers>
         <developer>
@@ -47,6 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <github.global.server>github</github.global.server>
         <env.GEM_PATH>${project.basedir}/.generated/build/gems</env.GEM_PATH>
+        <maven-compiler-plugin.source>1.8</maven-compiler-plugin.source>
+        <maven-compiler-plugin.target>1.8</maven-compiler-plugin.target>
         <!-- END: project settings -->
         <!-- BEGIN: product dependencies -->
         <combinatoradix.version>0.9.2</combinatoradix.version>
@@ -150,29 +152,148 @@
                     <version>${maven-resources-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <version>${exec-maven-plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <source>${maven-compiler-plugin.source}</source>
+                        <target>${maven-compiler-plugin.target}</target>
+                        <compilerArgs>
+                            <!--
+                            <arg>-Xlint:all,-options,-path</arg>
+                            -->
+                        </compilerArgs>
+                    </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>${maven-source-plugin.version}</version>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>3.0.0</version> <!-- Use the version that suits your needs -->
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <!-- configuration>
+                        <argLine>-ea</argLine>
+                    </configuration -->
+                    <executions>
+                        <execution>
+                            <phase>integration-test</phase>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <excludes>
+                                    <exclude>none</exclude>
+                                </excludes>
+                                <includes>
+                                    <include>**/*IT</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco-maven-plugin.version}</version>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${build-helper-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>
+                                        ${project.build.directory}/generated-sources/local
+                                    </source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <version>${exec-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                    <dependencies>
+                        <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                        <dependency>
+                            <groupId>org.jruby</groupId>
+                            <artifactId>jruby-complete</artifactId>
+                            <version>${jruby.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctor-maven-plugin</artifactId>
+                            <version>${asciidoctor.maven.plugin.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <!-- disable generateReports if you don't want to include the built-in reports -->
+                        <generateReports>true</generateReports>
+                        <generateSitemap>true</generateSitemap>
+                        <relativizeDecorationLinks>false</relativizeDecorationLinks>
+                        <locales>en</locales>
+                        <inputEncoding>UTF-8</inputEncoding>
+                        <outputEncoding>UTF-8</outputEncoding>
+                        <skipDeploy>false</skipDeploy>
+                        <!-- asciidoc -->
+                        <!-- optional site-wide AsciiDoc attributes -->
+                        <!-- attributes>
+                            <icons>font</icons>
+                            <source-highlighter>coderay</source-highlighter>
+                            <coderay-css>style</coderay-css>
+                            <toclevels>2</toclevels>
+                        </attributes>
+                    </asciidoc -->
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>${maven-project-info-reports-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -269,133 +390,120 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>${maven-site-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>${maven-project-info-reports-plugin.version}
-                    </version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>${maven-jar-plugin.version}</version>
-                    <configuration>
-                        <archive>
-                            <manifestFile>
-                                src/main/resources/META-INF/MANIFEST.MF
-                            </manifestFile>
-                        </archive>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>${maven-install-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${maven-release-plugin.version}</version>
+                    <configuration>
+                        <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <!-- Run with mvn org.pitest:pitest-maven:mutationCoverage -->
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>
                     <version>${pitest-maven.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>pre-site</phase>
+                            <goals>
+                                <goal>mutationCoverage</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <jvmArgs>
+                            <jvmArg>-ea</jvmArg>
+                            <jvmArg>-Dunderpitest=yes</jvmArg>
+                        </jvmArgs>
+                        <targetClasses>
+                            <param>com.github.valid8j.*</param>
+                        </targetClasses>
+                        <targetTests>
+                            <param>*Test</param>
+                        </targetTests>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>cobertura-maven-plugin</artifactId>
+                    <version>${cobertura-maven-plugin.version}</version>
+                    <configuration>
+                        <instrumentation>
+                            <includes>
+                                <include>com/github/valid8j/**/*.class</include>
+                            </includes>
+                        </instrumentation>
+                        <formats>
+                            <format>html</format>
+                            <format>xml</format>
+                        </formats>
+                        <check />
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>com/github/valid8j/**/*.class</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <!-- attached to Maven test phase -->
+                        <execution>
+                            <id>report</id>
+                            <phase>pre-site</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgs>
-                        <!--
-                        <arg>-Xlint:all,-options,-path</arg>
-                        -->
-                    </compilerArgs>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- configuration>
-                    <argLine>-ea</argLine>
-                </configuration -->
             </plugin>
             <plugin>
                 <!-- Run with mvn org.pitest:pitest-maven:mutationCoverage -->
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.pitest</groupId>
-                        <artifactId>pitest-junit5-plugin</artifactId>
-                        <version>${pitest-junit5-plugin.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <phase>pre-site</phase>
-                        <goals>
-                            <goal>mutationCoverage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmArgs>
-                        <jvmArg>-ea</jvmArg>
-                        <jvmArg>-Dunderpitest=yes</jvmArg>
-                    </jvmArgs>
-                    <targetClasses>
-                        <param>com.github.jcunit.*</param>
-                    </targetClasses>
-                    <targetTests>
-                        <param>*Test</param>
-                    </targetTests>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <!-- attached to Maven test phase -->
-                    <execution>
-                        <id>report</id>
-                        <phase>pre-site</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -412,21 +520,6 @@
                             <arguments>
                                 <argument>
                                     ${basedir}/src/build_tools/remove-adoc-diags.sh
-                                </argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution><!-- Remove diagram caches -->
-                        <id>remove package-info.java files</id>
-                        <phase>clean</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>bash</executable>
-                            <arguments>
-                                <argument>
-                                    ${basedir}/src/build_tools/remove-package-info-java.sh
                                 </argument>
                             </arguments>
                         </configuration>
@@ -489,45 +582,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <dependencies>
-                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                    <dependency>
-                        <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
-                        <version>${jruby.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctor-maven-plugin</artifactId>
-                        <version>${asciidoctor.maven.plugin.version}</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <!-- disable generateReports if you don't want to include the built-in reports -->
-                    <generateReports>true</generateReports>
-                    <generateSitemap>true</generateSitemap>
-                    <relativizeDecorationLinks>false</relativizeDecorationLinks>
-                    <locales>en</locales>
-                    <inputEncoding>UTF-8</inputEncoding>
-                    <outputEncoding>UTF-8</outputEncoding>
-                    <skipDeploy>false</skipDeploy>
-                    <!-- asciidoc -->
-                    <!-- optional site-wide AsciiDoc attributes -->
-                    <!-- attributes>
-                        <icons>font</icons>
-                        <source-highlighter>coderay</source-highlighter>
-                        <coderay-css>style</coderay-css>
-                        <toclevels>2</toclevels>
-                    </attributes>
-                </asciidoc -->
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
-                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -599,23 +657,6 @@
 
     <profiles>
         <profile>
-            <id>mac</id>
-            <activation>
-                <os>
-                    <family>mac</family>
-                </os>
-            </activation>
-        </profile>
-        <profile>
-            <id>unix</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                    <name>Linux</name>
-                </os>
-            </activation>
-        </profile>
-        <profile>
             <id>release-sign-artifacts</id>
             <activation>
                 <property>
@@ -628,7 +669,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
                         <configuration>
                             <passphrase>${gpg.passphrase}</passphrase>
                         </configuration>

--- a/src/build_tools/lib/mvn-utils.rc
+++ b/src/build_tools/lib/mvn-utils.rc
@@ -9,7 +9,7 @@ function mvn_init() {
 }
 
 function project_name() {
-  xmllint --xpath '/project/name/text()' <(sed -E 's/xmlns=[^ ]+//g' pom.xml)
+  xmllint --xpath '/project/name/text()' <(sed -E 's/xmlns=[^\s]+//g' pom.xml)
 }
 
 function _compose_mvn_command_line() {

--- a/src/build_tools/package-info-adoc_to_package-info-java.sh
+++ b/src/build_tools/package-info-adoc_to_package-info-java.sh
@@ -12,7 +12,7 @@ function convert_package_info_adoc_to_package_info_java() {
   while IFS= read -r _i
   do
     echo " * ${_i}" >> ${_out}
-  done < "${_base_dir}/${_rel_dir}/package-info.adoc"
+  done < <(cat "${_base_dir}/${_rel_dir}/package-info.adoc" <(echo ""))
 
   echo " */" >> ${_out}
   echo "package ${_rel_dir//\//.};" >> ${_out}

--- a/src/main/java/com/github/jcunit/annotations/ConfigurePipelineWith.java
+++ b/src/main/java/com/github/jcunit/annotations/ConfigurePipelineWith.java
@@ -2,7 +2,7 @@ package com.github.jcunit.annotations;
 
 import com.github.jcunit.core.tuples.Tuple;
 import com.github.jcunit.factorspace.ParameterSpace;
-import com.github.jcunit.pipeline.ParseConfigWith;
+import com.github.jcunit.pipeline.ParseConfigArgumentsWith;
 import com.github.jcunit.pipeline.Pipeline;
 import com.github.jcunit.pipeline.PipelineConfig;
 import com.github.jcunit.pipeline.PipelineSpec;
@@ -122,7 +122,7 @@ public @interface ConfigurePipelineWith {
     private static PipelineConfigArgumentsParser getArgumentsParser(ConfigurePipelineWith configuration) {
       try {
         return configuration.value()
-                            .getAnnotation(ParseConfigWith.class)
+                            .getAnnotation(ParseConfigArgumentsWith.class)
                             .value()
                             .getConstructor()
                             .newInstance();

--- a/src/main/java/com/github/jcunit/package-info.adoc
+++ b/src/main/java/com/github/jcunit/package-info.adoc
@@ -1,19 +1,7 @@
 You can describe a package's design that disciples classes under it here.
 
-[ditaa]
-.Ditaa
-----
-+---+   +---+
-|ABC+-->|XYZ|
-+---+   +---+
 
-----
+// Due to AsciiDoclet's behavior, texts placed in this package-info.adoc will not be treated as asciidoc texts, but as plain texts.
+// In case you want to place a rich documents generated from asciidoc at the top level of JavaDoc, do it in the `overview.adoc`.
+// You can use asciidoc feature in the other files.
 
-
-[plantuml]
-.PlantUML diagram
-----
-class Java8App {
-+main(String... args): String
-}
-----

--- a/src/main/java/com/github/jcunit/pipeline/ParseConfigArgumentsWith.java
+++ b/src/main/java/com/github/jcunit/pipeline/ParseConfigArgumentsWith.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
-public @interface ParseConfigWith {
+public @interface ParseConfigArgumentsWith {
   Class<? extends ConfigurePipelineWith.PipelineConfigArgumentsParser> value();
 }

--- a/src/main/java/com/github/jcunit/pipeline/Pipeline.java
+++ b/src/main/java/com/github/jcunit/pipeline/Pipeline.java
@@ -19,6 +19,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.github.jcunit.pipeline.Pipeline.Standard.ConfigArgumentsParser.Keyword.*;
 import static com.github.valid8j.classic.Requires.requireNonNull;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -30,7 +31,7 @@ public interface Pipeline {
 
   TestSuite execute(ParameterSpace parameterSpace);
 
-  @ParseConfigWith(Standard.ConfigArgumentsParser.class)
+  @ParseConfigArgumentsWith(Standard.ConfigArgumentsParser.class)
   class Standard implements Pipeline {
     public static class ConfigArgumentsParser implements ConfigurePipelineWith.PipelineConfigArgumentsParser {
       enum Keyword {
@@ -56,16 +57,16 @@ public interface Pipeline {
          */
 
         validateConfigEntries(configEntries);
-        int strength = findConfigEntryValueByName("strength", configEntries)
+        int strength = findConfigEntryValueByName(STRENGTH.keyword, configEntries)
             .map((String[] v) -> v[0])
             .map(Integer::parseInt)
             .orElseThrow(AssertionError::new);
-        boolean negativeTestsEnabled = findConfigEntryValueByName("negativeTestGeneration", configEntries)
+        boolean negativeTestsEnabled = findConfigEntryValueByName(NEGATIVE_TEST_GENERATION.keyword, configEntries)
             .map((String[] v) -> v[0])
             .map(Boolean::parseBoolean)
             .orElseThrow(AssertionError::new);
         List<Tuple> seeds = Arrays.stream(configEntries)
-                                  .filter(e -> Objects.equals(e.name(), Keyword.SEED_GENERATOR_METHOD.keyword))
+                                  .filter(e -> Objects.equals(e.name(), SEED_GENERATOR_METHOD.keyword))
                                   .flatMap(e -> Arrays.stream(e.value())
                                                       .peek(System.out::println)
                                                       .flatMap(g -> seedGenerators.get(g)

--- a/src/main/java/com/github/jcunit/utils/package-info.adoc
+++ b/src/main/java/com/github/jcunit/utils/package-info.adoc
@@ -1,0 +1,18 @@
+[source, java]
+.`Example` of `refl` package
+----
+public class Example {
+  public void example() {
+      requireArgument("hello", Predicates.callp("startsWith", "H"));
+  }
+}
+----
+
+[ditaa]
+.Ditaa
+----
++---+   +---+
+|ABC+-->|XYZ|
++---+   +---+
+
+----


### PR DESCRIPTION
- Rename annotation class ParseConfigWith to ParseConfigArgumentsWith to reflect what it really does.
- Use enum value rather than separate literals to refer to known keywords in config arguments.